### PR TITLE
fix: update error output for clarity, update docs for tofuenv use

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,10 +380,9 @@ Switch a version to use
 If no parameter is passed, the version to use is resolved automatically via [.opentofu-version files](#opentofu-version-file) or [TOFUENV_TOFU_VERSION environment variable](#TOFUENV_TOFU_VERSION) (TOFUENV_TOFU_VERSION takes precedence), defaulting to 'latest' if none are found.
 
 `latest` is a syntax to use the latest installed version
-
 `latest:<regex>` is a syntax to use latest installed version matching regex (used by grep -e)
-
 `min-required` will switch to the version minimally required by your tofu sources (see above `tofuenv install`)
+`latest-allowed` will switch to the version maximally allowed by your tofu sources (see above `tofuenv install`).
 
 ```console
 $ tofuenv use
@@ -391,9 +390,10 @@ $ tofuenv use min-required
 $ tofuenv use 0.7.0
 $ tofuenv use latest
 $ tofuenv use latest:^0.8
+$ tofuenv use latest-allowed
 ```
 
-Note: `tofuenv use latest` or `tofuenv use latest:<regex>` will find the latest matching version that is already installed. If no matching versions are installed, and TOFUENV_AUTO_INSTALL is set to `true` (which is the default) the the latest matching version in the remote repository will be installed and used.
+Note: `tofuenv use latest` or `tofuenv use latest:<regex>` will find the latest matching version that is already installed. If no matching versions are installed, and TOFUENV_AUTO_INSTALL is set to `true` (which is the default) the latest matching version in the remote repository will be installed and used.
 
 ### tofuenv uninstall &lt;version>
 

--- a/libexec/tofuenv-install
+++ b/libexec/tofuenv-install
@@ -74,7 +74,7 @@ declare regex="${resolved##*\:}";
 log 'debug' "Processing install for version ${version}, using regex ${regex}";
 
 remote_version="$(tofuenv-list-remote | grep -e "${regex}" | head -n 1)";
-[ -n "${remote_version}" ] && version="${remote_version}" || log 'error' "No versions matching '${requested:-$version}' found in remote";
+[ -n "${remote_version}" ] && version="${remote_version}" || log 'error' "No ${version} versions matching '${regex}' found in remote";
 
 dst_path="${TOFUENV_CONFIG_DIR}/versions/${version}";
 if [ -f "${dst_path}/tofu" ]; then

--- a/libexec/tofuenv-use
+++ b/libexec/tofuenv-use
@@ -91,11 +91,11 @@ log debug "Resolving version with: tofuenv-resolve-version ${requested_arg}";
 declare resolved="$(tofuenv-resolve-version ${requested_arg})";
 [ -z "${resolved}" ] && log 'error' "Failure to resolve version from ${requested_arg}";
 
-log debug "Resolved to: ${resolved}";
-
 declare version="${resolved%%\:*}";
 declare regex="${resolved##*\:}";
 declare installed_version='';
+
+log 'debug' "Resolved to ${resolved} version, ${regex} regex";
 
 log 'debug' "Searching ${TOFUENV_CONFIG_DIR}/versions/ for latest version matching ${regex}";
 
@@ -112,7 +112,7 @@ if [ -n "${installed_version}" ]; then
   log 'debug' "Found version: ${installed_version}";
 else
   if [ "${auto_install}" == 'true' ]; then
-    log 'info' "No installed versions of opentofu matched '${resolved}'. Trying to install a matching version since TOFUENV_AUTO_INSTALL=true";
+    log 'info' "No installed versions of opentofu matched '${regex}'. Trying to install a matching version since TOFUENV_AUTO_INSTALL=true";
 
     declare install_version='';
     [ "${version}" == 'latest' ] && install_version="${version}:${regex}" || install_version="${version}";

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -180,7 +180,10 @@ for ((test_iter=0; test_iter<${neg_tests_count}; ++test_iter )) ; do
   test_num=$((test_iter + 1));
   desc=${neg_tests__desc[${test_iter}]}
   k="${neg_tests__kv[${test_iter}]}";
-  expected_error_message="No versions matching '${k}' found in remote";
+  v="${k%%\:*} ";
+  regex="${k##*\:}";
+  if [[ "${v}" =~ ${regex} ]]; then v=''; fi
+  expected_error_message="No ${v}versions matching '${regex}' found in remote";
   log 'info' "##  Invalid Version Test ${test_num}/${neg_tests_count}: ${desc} ( ${k} )";
   [ -z "$(tofuenv install "${k}" 2>&1 | grep "${expected_error_message}")" ] \
     && error_and_proceed "Installing invalid version ${k}";


### PR DESCRIPTION
Updated logging for tofuenv use and install commands, updated readme.

Before:
- run `tofuenv use` without arguments
- Output:
`No versions matching 'latest:^[0-9]\+\.[0-9]\+\.[0-9]\+$' found in remote`

After:
- run `tofuenv use` without arguments
- Output:
`No latest versions matching '^[0-9]\+\.[0-9]\+\.[0-9]\+$' found in remote`

This change improves clarity about the exact regex used to search and excludes confusion that might be caused by the previous error description.

Tests:
`tofuenv use latest:2.10`
No latest versions matching '2.10' found in remote
`tofuenv use 2.1.0`
No 2.1.0 versions matching '^2.1.0$' found in remote
`tofuenv use latest:^0.8`
No latest versions matching '^0.8' found in remote