### PR TITLE
fix: update docs and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,7 @@ String (Default: true)
 Should tofuenv automatically install tofu if the version specified by defaults or a .opentofu-version file is not currently installed.
 
 ```console
-TOFUENV_AUTO_INSTALL=false tofu plan
-```
-
-```console
-tofu use <version that is not yet installed>
+TOFUENV_AUTO_INSTALL=true tofu use <version that is not yet installed>
 ```
 
 ##### `TOFUENV_CURL_OUTPUT`

--- a/libexec/tofuenv-use
+++ b/libexec/tofuenv-use
@@ -110,8 +110,7 @@ fi;
 
 if [ -n "${installed_version}" ]; then
   log 'debug' "Found version: ${installed_version}";
-else
-  if [ "${auto_install}" == 'true' ]; then
+elif [ "${auto_install}" == 'true' ]; then
     log 'info' "No installed versions of opentofu matched '${regex}'. Trying to install a matching version since TOFUENV_AUTO_INSTALL=true";
 
     declare install_version='';
@@ -128,7 +127,8 @@ else
 
     [ -n "${installed_version}" ] \
       || log 'error' "Despite successfully installing a version matching '${resolved}', a matching version could not be found in '${TOFUENV_CONFIG_DIR}/versions/' - This should be pretty much impossible";
-  fi;
+else
+  log 'error' "No installed versions of opentofu matched '${regex}'. TOFUENV_AUTO_INSTALL is set to false, so exiting."
 fi;
 
 target_path="${TOFUENV_CONFIG_DIR}/versions/${installed_version}";


### PR DESCRIPTION
Update example commands for `TOFUENV_AUTO_INSTALL` usage in readme 
Update logging for `TOFUENV_AUTO_INSTALL=false tofuenv use <version>` command when version is not installed

Before:
$ TOFUENV_AUTO_INSTALL=false tofuenv use 1.6.0-beta3
`Version directory for  is present, but the opentofu binary is not! Manual intervention required.`

After:
$ TOFUENV_AUTO_INSTALL=false tofuenv use 1.6.0-beta3
`No installed versions of opentofu matched '^1.6.0-beta3$'. TOFUENV_AUTO_INSTALL is set to false, so exiting.`