### PR TITLE
feat: add release action

### DIFF
--- a/.github/.goreleaser.yml
+++ b/.github/.goreleaser.yml
@@ -1,0 +1,12 @@
+version: 1
+
+builds:
+  - skip: true
+    env:
+      - CGO_ENABLED=0
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^test:'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+---
+name: 'Release'
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: 'Release the latest tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean -f ${{ vars.GORELEASER_CONFIG_PATH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOFUENV_GITHUB_TOKEN }}
+      - name: Download artifacts
+        uses: robinraju/release-downloader@v1.8
+        with:
+          tag: ${{ github.ref_name }}
+          tarBall: true
+          zipBall: true
+      - name: Check contents
+        run: ls -la
+      - name: Generate checksum
+        uses: jmgilman/actions-generate-checksum@v1
+        with:
+          patterns: |
+            *.zip
+            *.tar.gz
+          method: sha256
+          output: checksums_${{ github.ref_name }}.txt
+      - name: Upload checksum to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.TOFUENV_GITHUB_TOKEN }}
+          file: checksums_${{ github.ref_name }}.txt
+          tag: ${{ github.ref_name }}


### PR DESCRIPTION
Add a release action to create releases using goreleaser when a new tag is pushed to the repository.
The release will contain source code archives and checksums file for these archives.