### PR TITLE
FIX Support default tofu version

### DIFF
--- a/.changelog/47.txt
+++ b/.changelog/47.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+feature: support `TOFUENV_TOFU_DEFAULT_VERSION` env variable to provide a default version for all operations ([#34](https://github.com/tofuutils/tofuenv/issues/34))
+```

--- a/README.md
+++ b/README.md
@@ -139,7 +139,13 @@ curl -L -o /usr/bin/jq.exe https://github.com/jqlang/jq/releases/latest/download
 
 Install a specific version of OpenTofu.
 
-If no parameter is passed, the version to use is resolved automatically via [TOFUENV_TOFU_VERSION environment variable](#TOFUENV_TOFU_VERSION) or [.opentofu-version files](#opentofu-version-file), in that order of precedence, i.e. TOFUENV_TOFU_VERSION, then .opentofu-version. The default is `latest` if none are found.
+If no parameter is passed, the version to use is resolved automatically via the following:
+
+- [TOFUENV_TOFU_VERSION environment variable](#TOFUENV_TOFU_VERSION)
+- [.opentofu-version files](#opentofu-version-file)
+- [TOFUENV_CONFIG_DIR](#TOFUENV_CONFIG_DIR)`/version`
+- [TOFUENV_TOFU_DEFAULT_VERSION](#TOFUENV_TOFU_DEFAULT_VERSION)
+- The default of `latest`.
 
 If a parameter is passed, available options:
 
@@ -212,6 +218,12 @@ terraform {
 ### Environment Variables
 
 #### TOFUENV
+
+##### `TOFUENV_TOFU_DEFAULT_VERSION`
+
+String (Default: "latest")
+
+Specify which version of tofu to install if no other version information can be found.
 
 ##### `TOFUENV_GITHUB_TOKEN`
 

--- a/lib/tofuenv-version-name.sh
+++ b/lib/tofuenv-version-name.sh
@@ -10,10 +10,14 @@ function tofuenv-version-name() {
       && log 'debug' "TOFUENV_VERSION_FILE retrieved from tofuenv-version-file: ${TOFUENV_VERSION_FILE}" \
       || log 'error' 'Failed to retrieve TOFUENV_VERSION_FILE from tofuenv-version-file';
 
-    TOFUENV_VERSION="$(cat "${TOFUENV_VERSION_FILE}" || true)" \
-      && log 'debug' "TOFUENV_VERSION specified in TOFUENV_VERSION_FILE: ${TOFUENV_VERSION}";
-
-    TOFUENV_VERSION_SOURCE="${TOFUENV_VERSION_FILE}";
+    if [[ -f "${TOFUENV_VERSION_FILE}" ]]; then
+        TOFUENV_VERSION="$(cat "${TOFUENV_VERSION_FILE}" || true)" \
+            && log 'debug' "TOFUENV_VERSION specified in TOFUENV_VERSION_FILE: ${TOFUENV_VERSION}";
+        TOFUENV_VERSION_SOURCE="${TOFUENV_VERSION_FILE}";
+    else
+        TOFUENV_VERSION="${TOFUENV_TOFU_DEFAULT_VERSION:-"latest"}";
+        TOFUENV_VERSION_SOURCE='TOFUENV_TOFU_DEFAULT_VERSION';
+    fi;
 
   else
     TOFUENV_VERSION="${TOFUENV_TOFU_VERSION}" \

--- a/libexec/tofuenv-resolve-version
+++ b/libexec/tofuenv-resolve-version
@@ -71,30 +71,18 @@ declare version_requested version regex min_required version_file;
 
 declare arg="${1:-""}";
 
-if [ -z "${arg}" -a -z "${TOFUENV_TOFU_VERSION:-""}" ]; then
-  version_file="$(tofuenv-version-file)";
-  log 'debug' "Version File: ${version_file}";
+if [ -z "${arg}" ] && [ -z "${TOFUENV_TOFU_VERSION:-""}" ]; then
+  log 'debug' 'We are not hardcoded by a TOFUENV_TOFU_VERSION environment variable';
 
-  if [ "${version_file}" != "${TOFUENV_CONFIG_DIR}/version" ]; then
-    log 'debug' "Version File (${version_file}) is not the default \${TOFUENV_CONFIG_DIR}/version (${TOFUENV_CONFIG_DIR}/version)";
-    version_requested="$(cat "${version_file}")" \
-      || log 'error' "Failed to open ${version_file}";
+  version_file="$(tofuenv-version-file)" \
+    && log 'debug' "Version file retrieved from tofuenv-version-file: ${version_file}" \
+    || log 'error' 'Failed to retrieve version file from tofuenv-version-file';
 
-  elif [ -f "${version_file}" ]; then
-    log 'debug' "Version File is the default \${TOFUENV_CONFIG_DIR}/version (${TOFUENV_CONFIG_DIR}/version)";
-    version_requested="$(cat "${version_file}")" \
-      || log 'error' "Failed to open ${version_file}";
-
-    # Absolute fallback
-    if [ -z "${version_requested}" ]; then
-      log 'debug' 'Version file had no content. Falling back to "latest"';
-      version_requested='latest';
-    fi;
-
-  else 
-    log 'debug' "Version File is the default \${TOFUENV_CONFIG_DIR}/version (${TOFUENV_CONFIG_DIR}/version) but it doesn't exist";
-    log 'debug' 'No version requested on the command line or in the version file search path. Installing "latest"';
-    version_requested='latest';
+  if [[ -f "${version_file}" ]]; then
+    version_requested="$(cat "${version_file}" || true)" \
+      && log 'debug' "Version specified in ${version_file}: ${version_requested}";
+  else
+    version_requested="${TOFUENV_TOFU_DEFAULT_VERSION:-"latest"}";
   fi;
 elif [ -n "${TOFUENV_TOFU_VERSION:-""}" ]; then
   version_requested="${TOFUENV_TOFU_VERSION}";

--- a/test/test_uninstall.sh
+++ b/test/test_uninstall.sh
@@ -56,7 +56,7 @@ function test_uninstall() {
   tofuenv install "${v}" || return 1;
   tofuenv uninstall "${v}" || return 1;
   log 'info' 'Confirming uninstall success; an error indicates success:';
-  check_active_version "${v}" && return 1 || return 0;
+  env TOFUENV_AUTO_INSTALL=false "${TOFUENV_ROOT}/bin/tofu" version && return 1 || return 0;
 };
 
 log 'info' '### Test Suite: Uninstall Local Versions';
@@ -88,13 +88,13 @@ done;
 echo "### Uninstall removes versions directory"
 cleanup || error_and_die "Cleanup failed?!"
 (
-  tofuenv install 1.6.0-beta5 || exit 1
-  tofuenv install 1.6.0-beta4 || exit 1
-  [ -d "./versions" ] || exit 1
-  tofuenv uninstall 1.6.0-beta5 || exit 1
-  [ -d "./versions" ] || exit 1
-  tofuenv uninstall 1.6.0-beta4 || exit 1
-  [ -d "./versions" ] && exit 1 || exit 0
+  tofuenv install 1.6.0-beta5 || error_and_die "Failed to install 1.6.0-beta5"
+  tofuenv install 1.6.0-beta4 || error_and_die "Failed to install 1.6.0-beta"
+  [ -d "./versions" ] || error_and_die "Versions directory does not exist"
+  tofuenv uninstall 1.6.0-beta5 || error_and_die "Failed to uninstall 1.6.0-beta5"
+  [ -d "./versions" ] || error_and_die "Versions directory does not exist - 2"
+  tofuenv uninstall 1.6.0-beta4 || error_and_die "Failed to uninstall 1.6.0-beta4"
+  [ -d "./versions" ] && error_and_die "Versions directory exists but shouldn't" || exit 0
 ) || error_and_proceed "Removing last version deletes versions directory"
 
 if [ "${#errors[@]}" -gt 0 ]; then


### PR DESCRIPTION
Support an environment variable for the default version of OpenTofu if no other version information is found.

Being an environment variable gives more flexibility than the existing ``${TOFUENV_CONFIG_DIR}/version` solution, in that you can easily set the environment variable for the process you are running.

This resolves #34 