### PR TITLE
feat: add gpg verification during tofuenv install

### DIFF
--- a/.changelog/44.txt
+++ b/.changelog/44.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+feature: add gpg verification support during opentofu installation
+```

--- a/README.md
+++ b/README.md
@@ -148,7 +148,28 @@ $ tofuenv install min-required
 
 If `shasum` is present in the path, tofuenv will verify the download against OpenTofu published sha256 hash.
 
-For now keybase and GnuPG tools for PGP signature verification are not supported by OpenTofu. Verification mechanisms will be added after support is added by OpenTofu.
+You can opt-in to using GnuPG tools for GPG signature verification:
+
+
+```console
+echo 'trust-tofuenv: yes' > ${TOFUENV_INSTALL_DIR}/use-gpgv
+tofuenv install
+```
+Where `TOFUENV_INSTALL_DIR` is for example, `~/tofuenv` or `/opt/homebrew/Cellar/tofuenv/<version>`
+
+The `trust-tofuenv` directive means that verification uses a copy of the
+OpenTofu GPG key found in the tofuenv repository. Skipping that directive
+means that the OpenTofu key must be in the existing default trusted keys.
+Use the file `${TOFUENV_INSTALL_DIR}/use-gnupg` to instead invoke the full `gpg` tool and
+see web-of-trust status; beware that a lack of trust path will not cause a
+validation failure.
+Default `gpg/gpgv` command can be overridden by adding `binary` directive to `use-gpgv`/`use-gnupg` file, ex.:
+```console
+echo 'binary: gpgv --keyring ./path/to/gpg/opentofu.gpg' > ${TOFUENV_INSTALL_DIR}/use-gpgv
+tofuenv install
+```
+
+For now keybase tool GPG signature verification is not supported by OpenTofu. This verification mechanism will be added after support is added by OpenTofu.
 
 #### .opentofu-version
 

--- a/README.md
+++ b/README.md
@@ -113,11 +113,6 @@ echo 'export PATH=$PATH:$HOME/.tofuenv/bin' >> ~/.bashrc
 which tofuenv
 ```
 
-6. Install jq package into git-bash default installation folder:
-```console
-curl -L -o /usr/bin/jq.exe https://github.com/jqlang/jq/releases/latest/download/jq-win64.exe
-```
-
 ## Install dependencies
 
 Install jq (required) and GnuPG (optional, in case you want to enable GPG verification during OpenTofu installation)
@@ -130,6 +125,12 @@ brew install jq gnupg grep
 ```console
 sudo apt-get update -y
 sudo apt-get install -y jq gnupg
+```
+
+### Windows (git-bash)
+Install jq package into git-bash default installation folder:
+```console
+curl -L -o /usr/bin/jq.exe https://github.com/jqlang/jq/releases/latest/download/jq-win64.exe
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -118,6 +118,20 @@ which tofuenv
 curl -L -o /usr/bin/jq.exe https://github.com/jqlang/jq/releases/latest/download/jq-win64.exe
 ```
 
+## Install dependencies
+
+Install jq (required) and GnuPG (optional, in case you want to enable GPG verification during OpenTofu installation)
+### MacOS 
+```console
+brew install jq gnupg grep
+```
+
+### Linux
+```console
+sudo apt-get update -y
+sudo apt-get install -y jq gnupg
+```
+
 ## Usage
 
 ### tofuenv install [version]

--- a/libexec/tofuenv-install
+++ b/libexec/tofuenv-install
@@ -263,7 +263,7 @@ elif [[ -f "${TOFUENV_CONFIG_DIR}/use-gpgv" ]]; then
 #  fi;
 else
   # Warning about this avoids an unwarranted sense of confidence in the SHA check
-  log 'warn' "Not instructed to use Local PGP (${TOFUENV_CONFIG_DIR}/use-{gpgv,gnupg}), skipping OpenPGP signature verification";
+  log 'warn' "Not instructed to use Local GPG (${TOFUENV_CONFIG_DIR}/use-{gpgv,gnupg}), skipping GnuPG signature verification";
 fi;
 
 if [[ -n "${shasum_bin}" && -x "${shasum_bin}" ]]; then

--- a/libexec/tofuenv-install
+++ b/libexec/tofuenv-install
@@ -215,7 +215,6 @@ if [[ -f "${TOFUENV_CONFIG_DIR}/use-gnupg" ]]; then
   download_signature;
   # Deliberately unquoted command, in case caller has something fancier in "use-gnupg".
   # Also, don't use batch mode.  If someone specifies GnuPG, let them deal with any prompting.
-  echo yes
   ${gnupg_command} \
     --verify "${download_tmp}/${shasums_sig}" \
     "${download_tmp}/${shasums_name}" \

--- a/libexec/tofuenv-install
+++ b/libexec/tofuenv-install
@@ -139,7 +139,7 @@ version_url="${TOFUENV_REMOTE}/download/v${version}";
 tarball_name="tofu_${version}_${os}.zip";
 
 shasums_name="tofu_${version}_SHA256SUMS";
-shasums_sig="${shasums_name}.sig";
+shasums_sig="${shasums_name}.gpgsig";
 
 log 'info' "Installing OpenTofu v${version}";
 
@@ -203,9 +203,6 @@ download_signature() {
 # from "required_version" setting in "*.tf" files
 check_dependencies;
 
-#
-# TODO: Not supported by now from OpenTofu side
-#
 # Verify signature if verification mechanism (keybase, gpg, etc) is present
 if [[ -f "${TOFUENV_CONFIG_DIR}/use-gnupg" ]]; then
   # GnuPG uses the user's keyring, and any web-of-trust or local signatures or
@@ -218,6 +215,7 @@ if [[ -f "${TOFUENV_CONFIG_DIR}/use-gnupg" ]]; then
   download_signature;
   # Deliberately unquoted command, in case caller has something fancier in "use-gnupg".
   # Also, don't use batch mode.  If someone specifies GnuPG, let them deal with any prompting.
+  echo yes
   ${gnupg_command} \
     --verify "${download_tmp}/${shasums_sig}" \
     "${download_tmp}/${shasums_name}" \
@@ -234,7 +232,11 @@ elif [[ -f "${TOFUENV_CONFIG_DIR}/use-gpgv" ]]; then
 
   download_signature;
   if [[ "${trust_tofuenv}" == 'yes' ]]; then
-    log 'error' 'Opentofu does not currently support PGP signatures.';
+    ${gpgv_command} \
+      --keyring "${TOFUENV_ROOT}/share/opentofu.gpg" \
+      "${download_tmp}/${shasums_sig}" \
+      "${download_tmp}/${shasums_name}" \
+      || log 'error' 'PGP signature rejected';
 
   else
     ${gpgv_command} \
@@ -242,27 +244,27 @@ elif [[ -f "${TOFUENV_CONFIG_DIR}/use-gpgv" ]]; then
       "${download_tmp}/${shasums_name}" \
       || log 'error' 'PGP signature rejected';
   fi;
-elif [[ -n "${keybase_bin}" && -x "${keybase_bin}" ]]; then
-  grep -Eq '^Logged in:[[:space:]]*yes' <("${keybase_bin}" status);
-  keybase_logged_in="${?}";
-  grep -Fq hashicorp <("${keybase_bin}" list-following);
-  keybase_following_hc="${?}";
-
-  if [[ "${keybase_logged_in}" -ne 0 || "${keybase_following_hc}" -ne 0 ]]; then
-    log 'warn' 'Unable to verify OpenPGP signature unless logged into keybase and following hashicorp';
-  else
-    download_signature;
-    "${keybase_bin}" pgp verify \
-      -S hashicorp \
-      -d "${download_tmp}/${shasums_sig}" \
-      -i "${download_tmp}/${shasums_name}" \
-      && log 'debug' 'SHA256SUMS signature matched' \
-      || log 'error' 'SHA256SUMS signature does not match!';
-  fi;
-# TODO: disable warning for now
-#else
+# TODO: uncomment when keybase GPG support is added
+#elif [[ -n "${keybase_bin}" && -x "${keybase_bin}" ]]; then
+#  grep -Eq '^Logged in:[[:space:]]*yes' <("${keybase_bin}" status);
+#  keybase_logged_in="${?}";
+#  grep -Fq hashicorp <("${keybase_bin}" list-following);
+#  keybase_following_hc="${?}";
+#
+#  if [[ "${keybase_logged_in}" -ne 0 || "${keybase_following_hc}" -ne 0 ]]; then
+#    log 'warn' 'Unable to verify OpenPGP signature unless logged into keybase and following hashicorp';
+#  else
+#    download_signature;
+#    "${keybase_bin}" pgp verify \
+#      -S hashicorp \
+#      -d "${download_tmp}/${shasums_sig}" \
+#      -i "${download_tmp}/${shasums_name}" \
+#      && log 'debug' 'SHA256SUMS signature matched' \
+#      || log 'error' 'SHA256SUMS signature does not match!';
+#  fi;
+else
   # Warning about this avoids an unwarranted sense of confidence in the SHA check
-  # log 'warn' "Not instructed to use Local PGP (${TOFUENV_CONFIG_DIR}/use-{gpgv,gnupg}) & No keybase install found, skipping OpenPGP signature verification";
+  log 'warn' "Not instructed to use Local PGP (${TOFUENV_CONFIG_DIR}/use-{gpgv,gnupg}), skipping OpenPGP signature verification";
 fi;
 
 if [[ -n "${shasum_bin}" && -x "${shasum_bin}" ]]; then


### PR DESCRIPTION
This change adds the ability to enable gpg verification during opentofu installation.
Verification can be done by gpgv (use-gpgv file is required) or gpg (use-gnupg file is required) utilities.