### PR TITLE
Fix various ShellCheck violations

### DIFF
--- a/lib/tofuenv-bashlog.sh
+++ b/lib/tofuenv-bashlog.sh
@@ -40,7 +40,7 @@ function log() {
 
   shift 1;
 
-  local line="$@";
+  local line="$*";
 
   # RFC 5424
   #

--- a/lib/tofuenv-exec.sh
+++ b/lib/tofuenv-exec.sh
@@ -3,7 +3,7 @@
 set -uo pipefail;
 
 function tofuenv-exec() {
-  for _arg in ${@:1}; do
+  for _arg in "${@:1}"; do
     if [[ "${_arg}" == -chdir=* ]]; then
       log 'debug' "Found -chdir arg. Setting TOFUENV_DIR to: ${_arg#-chdir=}";
       export TOFUENV_DIR="${PWD}/${_arg#-chdir=}";
@@ -38,7 +38,7 @@ function tofuenv-exec() {
   TF_BIN_PATH="${TOFUENV_CONFIG_DIR}/versions/${TOFUENV_VERSION}/tofu";
   export PATH="${TF_BIN_PATH}:${PATH}";
   log 'debug' "TF_BIN_PATH added to PATH: ${TF_BIN_PATH}";
-  log 'debug' "Executing: ${TF_BIN_PATH} $@";
+  log 'debug' "Executing: ${TF_BIN_PATH} $*";
 
   exec "${TF_BIN_PATH}" "$@" \
   || log 'error' "Failed to execute: ${TF_BIN_PATH} $*";

--- a/lib/tofuenv-helpers.sh
+++ b/lib/tofuenv-helpers.sh
@@ -72,13 +72,13 @@ function curlw () {
     TLS_OPT="";
   fi;
 
-  if [[ ! -z "${TOFUENV_NETRC_PATH:-""}" ]]; then
+  if [[ -n "${TOFUENV_NETRC_PATH:-""}" ]]; then
     NETRC_OPT="--netrc-file ${TOFUENV_NETRC_PATH}";
   else
     NETRC_OPT="";
   fi;
 
-  if [[ ! -z "${TOFUENV_GITHUB_TOKEN:-""}" ]]; then
+  if [[ -n "${TOFUENV_GITHUB_TOKEN:-""}" ]]; then
     AUTHORIZATION_HEADER="Authorization: Bearer ${TOFUENV_GITHUB_TOKEN}";
   else
     AUTHORIZATION_HEADER="";
@@ -94,7 +94,7 @@ function check_active_version() {
       maybe_chdir="-chdir=${2}";
   fi;
 
-  local active_version="$(${TOFUENV_ROOT}/bin/tofu ${maybe_chdir} version | grep '^OpenTofu')";
+  local active_version="$("${TOFUENV_ROOT}/bin/tofu" ${maybe_chdir} version | grep '^OpenTofu')";
 
   if ! grep -E "^OpenTofu v${v}((-dev)|( \([a-f0-9]+\)))?( is already installed)?\$" <(echo "${active_version}"); then
     log 'debug' "Expected version ${v} but found ${active_version}";
@@ -109,7 +109,7 @@ export -f check_active_version;
 function check_installed_version() {
   local v="${1}";
   local bin="${TOFUENV_CONFIG_DIR}/versions/${v}/tofu";
-  [ -n "$(${bin} version | grep -E "^OpenTofu v${v}((-dev)|( \([a-f0-9]+\)))?$")" ];
+  "${bin}" version | grep -qE "^OpenTofu v${v}((-dev)|( \([a-f0-9]+\)))?$"
 };
 export -f check_installed_version;
 
@@ -122,18 +122,18 @@ export -f check_default_version;
 
 function cleanup() {
   log 'info' 'Performing cleanup';
-  local pwd="$(pwd)";
-  log 'debug' "Deleting ${pwd}/version";
+
+  log 'debug' "Deleting ${PWD}/version";
   rm -rf ./version;
-  log 'debug' "Deleting ${pwd}/versions";
+  log 'debug' "Deleting ${PWD}/versions";
   rm -rf ./versions;
-  log 'debug' "Deleting ${pwd}/.opentofu-version";
+  log 'debug' "Deleting ${PWD}/.opentofu-version";
   rm -rf ./.opentofu-version;
-  log 'debug' "Deleting ${pwd}/latest_allowed.tf";
+  log 'debug' "Deleting ${PWD}/latest_allowed.tf";
   rm -rf ./latest_allowed.tf;
-  log 'debug' "Deleting ${pwd}/min_required.tf";
+  log 'debug' "Deleting ${PWD}/min_required.tf";
   rm -rf ./min_required.tf;
-  log 'debug' "Deleting ${pwd}/chdir-dir";
+  log 'debug' "Deleting ${PWD}/chdir-dir";
   rm -rf ./chdir-dir;
 };
 export -f cleanup;
@@ -145,8 +145,8 @@ function error_and_proceed() {
 export -f error_and_proceed;
 
 function check_dependencies() {
-  if [[ $(uname) == 'Darwin' ]] && [ $(which brew) ]; then
-    if ! [ $(which ggrep) ]; then
+  if [[ $(uname) == 'Darwin' ]] && [ "$(which brew)" ]; then
+    if ! [ "$(which ggrep)" ]; then
       log 'error' 'A metaphysical dichotomy has caused this unit to overload and shut down. GNU Grep is a requirement and your Mac does not have it. Consider "brew install grep"';
     fi;
 

--- a/lib/tofuenv-min-required.sh
+++ b/lib/tofuenv-min-required.sh
@@ -5,7 +5,7 @@ set -uo pipefail;
 function tofuenv-min-required() {
   local path="${1:-${TOFUENV_DIR:-.}}";
 
-  local versions="$( echo $(cat ${path}/{*.tf,*.tf.json} 2>/dev/null | grep -Eh '^\s*[^#]*\s*required_version') | grep -o '[~=!<>]\{0,2\}\s*\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
+  local versions="$( echo $(cat "${path}"/{*.tf,*.tf.json} 2>/dev/null | grep -Eh '^\s*[^#]*\s*required_version') | grep -o '[~=!<>]\{0,2\}\s*\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
 
   if [[ "${versions}" =~ ([~=!<>]{0,2}[[:blank:]]*)([0-9]+[0-9.]+)[^0-9]*(-[a-z]+[0-9]+)? ]]; then
     qualifier="${BASH_REMATCH[1]}";
@@ -13,7 +13,7 @@ function tofuenv-min-required() {
     if [[ "${qualifier}" =~ ^!= ]]; then
       log 'debug' "required_version is a negation - we cannot guess the desired one, skipping.";
     else
-      local min_required_file="$(grep -Hn required_version ${path}/{*.tf,*.tf.json} 2>/dev/null | xargs)";
+      local min_required_file="$(grep -Hn required_version "${path}"/{*.tf,*.tf.json} 2>/dev/null | xargs)";
 
       # Probably not an advisable way to choose a tofu version,
       # but this is the way this functionality works in tofu:

--- a/libexec/tofuenv---version
+++ b/libexec/tofuenv---version
@@ -27,7 +27,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tofuenv-exec
+++ b/libexec/tofuenv-exec
@@ -31,7 +31,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tofuenv-help
+++ b/libexec/tofuenv-help
@@ -2,7 +2,7 @@
 
 set -uo pipefail;
 
-echo 'Usage: tofuenv [<global options>] <command> [<options>]
+echo "Usage: tofuenv [<global options>] <command> [<options>]
 
 Commands:
    install       Install a specific version of OpenTofu
@@ -18,6 +18,6 @@ Commands:
 Global options:
    --version     Print current version of tofuenv
    --help        Show this help output
-';
+";
 
 exit 0;

--- a/libexec/tofuenv-install
+++ b/libexec/tofuenv-install
@@ -17,7 +17,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tofuenv-list
+++ b/libexec/tofuenv-list
@@ -18,7 +18,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tofuenv-min-required
+++ b/libexec/tofuenv-min-required
@@ -20,7 +20,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tofuenv-pin
+++ b/libexec/tofuenv-pin
@@ -18,7 +18,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tofuenv-resolve-version
+++ b/libexec/tofuenv-resolve-version
@@ -20,7 +20,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;
@@ -71,7 +71,7 @@ declare version_requested version regex min_required version_file;
 
 declare arg="${1:-""}";
 
-if [ -z "${arg}" -a -z "${TOFUENV_TOFU_VERSION:-""}" ]; then
+if [ -z "${arg}" ] && [ -z "${TOFUENV_TOFU_VERSION:-""}" ]; then
   version_file="$(tofuenv-version-file)";
   log 'debug' "Version File: ${version_file}";
 

--- a/libexec/tofuenv-uninstall
+++ b/libexec/tofuenv-uninstall
@@ -18,7 +18,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;
@@ -64,7 +64,7 @@ done;
 declare version_requested version regex;
 declare arg="${1:-""}";
 
-if [ -z "${arg:-""}" -a -z "${TOFUENV_TOFU_VERSION:-""}" ]; then
+if [ -z "${arg:-""}" ] && [ -z "${TOFUENV_TOFU_VERSION:-""}" ]; then
   version_file="$(tofuenv-version-file)";
   log 'debug' "Version File: ${version_file}";
   if [ "${version_file}" != "${TOFUENV_CONFIG_DIR}/version" ]; then

--- a/libexec/tofuenv-use
+++ b/libexec/tofuenv-use
@@ -17,7 +17,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;
@@ -72,7 +72,7 @@ declare version_source_suffix="";
 declare requested="${requested_arg}";
 declare loaded_version_file="$(tofuenv-version-file)";
 
-if [ -z "${requested_arg}" -a -z "${TOFUENV_TOFU_VERSION:-""}" ]; then
+if [ -z "${requested_arg}" ] && [ -z "${TOFUENV_TOFU_VERSION:-""}" ]; then
   version_source_suffix=" (set by ${loaded_version_file})";
 
   if [ -f "${loaded_version_file}" ]; then

--- a/libexec/tofuenv-version-file
+++ b/libexec/tofuenv-version-file
@@ -20,7 +20,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tofuenv-version-name
+++ b/libexec/tofuenv-version-name
@@ -19,7 +19,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -9,14 +9,14 @@ __parent="$(dirname "$__dir")"
 CHANGELOG_FILE_NAME="CHANGELOG.md"
 CHANGELOG_TMP_FILE_NAME="CHANGELOG.tmp"
 TARGET_SHA=$(git rev-parse HEAD)
-PREVIOUS_RELEASE_SHA=$(git rev-list -n 1 $(git describe --abbrev=0 --match='v*.*.*' --tags))
+PREVIOUS_RELEASE_SHA=$(git rev-list -n 1 "$(git describe --abbrev=0 --match='v*.*.*' --tags)")
 
-if [ $TARGET_SHA == $PREVIOUS_RELEASE_SHA ]; then
+if [ "$TARGET_SHA" == "$PREVIOUS_RELEASE_SHA" ]; then
   echo "Nothing to do"
   exit 0
 fi
 
-PREVIOUS_CHANGELOG=$(sed -n -e "/## $(git describe --abbrev=0 --match='v*.*.*' --tags | tr -d v)/,\$p" $__parent/$CHANGELOG_FILE_NAME)
+PREVIOUS_CHANGELOG=$(sed -n -e "/## $(git describe --abbrev=0 --match='v*.*.*' --tags | tr -d v)/,\$p" "$__parent/$CHANGELOG_FILE_NAME")
 
 if [ -z "$PREVIOUS_CHANGELOG" ]
 then
@@ -24,12 +24,12 @@ then
     exit 1
 fi
 
-CHANGELOG=$($(go env GOPATH)/bin/changelog-build -this-release $TARGET_SHA \
-                      -last-release $PREVIOUS_RELEASE_SHA \
-                      -git-dir $__parent \
+CHANGELOG=$("$(go env GOPATH)/bin/changelog-build" -this-release "$TARGET_SHA" \
+                      -last-release "$PREVIOUS_RELEASE_SHA" \
+                      -git-dir "$__parent" \
                       -entries-dir .changelog \
-                      -changelog-template $__dir/changelog.tmpl \
-                      -note-template $__dir/release-note.tmpl)
+                      -changelog-template "$__dir/changelog.tmpl" \
+                      -note-template "$__dir/release-note.tmpl")
 
 if [ -z "$CHANGELOG" ]
 then
@@ -39,14 +39,14 @@ fi
 
 rm -f $CHANGELOG_TMP_FILE_NAME
 
-sed -n -e "1{/## /p;}" $__parent/$CHANGELOG_FILE_NAME > $CHANGELOG_TMP_FILE_NAME
-echo "$CHANGELOG" >> $CHANGELOG_TMP_FILE_NAME
-echo >> $CHANGELOG_TMP_FILE_NAME
-echo "$PREVIOUS_CHANGELOG" >> $CHANGELOG_TMP_FILE_NAME
+sed -n -e "1{/## /p;}" "$__parent/$CHANGELOG_FILE_NAME" > "$CHANGELOG_TMP_FILE_NAME"
+echo "$CHANGELOG" >> "$CHANGELOG_TMP_FILE_NAME"
+echo >> "$CHANGELOG_TMP_FILE_NAME"
+echo "$PREVIOUS_CHANGELOG" >> "$CHANGELOG_TMP_FILE_NAME"
 
-cp $CHANGELOG_TMP_FILE_NAME $CHANGELOG_FILE_NAME
+cp "$CHANGELOG_TMP_FILE_NAME" "$CHANGELOG_FILE_NAME"
 
-rm $CHANGELOG_TMP_FILE_NAME
+rm "$CHANGELOG_TMP_FILE_NAME"
 
 echo "Successfully generated changelog."
 

--- a/test/install_deps.sh
+++ b/test/install_deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -uo pipefail;
 
-if [[ $(uname) == 'Darwin' ]] && [ $(which brew) ]; then
+if [[ $(uname) == 'Darwin' ]] && [ "$(which brew)" ]; then
   brew install grep;
 fi;

--- a/test/run.sh
+++ b/test/run.sh
@@ -17,7 +17,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;
@@ -26,7 +26,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
   };
 
   TOFUENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TOFUENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
+  [ -n "${TOFUENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
 else
   TOFUENV_ROOT="${TOFUENV_ROOT%/}";
 fi;
@@ -51,7 +51,7 @@ export PATH="${TOFUENV_ROOT}/bin:${PATH}";
 
 errors=();
 if [ "${#}" -ne 0 ]; then
-  targets="$@";
+  targets="$*";
 else
   targets="$(\ls "$(dirname "${0}")" | grep 'test_')";
 fi;

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -17,7 +17,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;
@@ -26,7 +26,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
   };
 
   TOFUENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TOFUENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
+  [ -n "${TOFUENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
 else
   TOFUENV_ROOT="${TOFUENV_ROOT%/}";
 fi;

--- a/test/test_list.sh
+++ b/test/test_list.sh
@@ -18,7 +18,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;
@@ -27,7 +27,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
   };
 
   TOFUENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TOFUENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
+  [ -n "${TOFUENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
 else
   TOFUENV_ROOT="${TOFUENV_ROOT%/}";
 fi;

--- a/test/test_symlink.sh
+++ b/test/test_symlink.sh
@@ -18,7 +18,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;
@@ -27,7 +27,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
   };
 
   TOFUENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TOFUENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
+  [ -n "${TOFUENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
 else
   TOFUENV_ROOT="${TOFUENV_ROOT%/}";
 fi;

--- a/test/test_uninstall.sh
+++ b/test/test_uninstall.sh
@@ -18,7 +18,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;
@@ -27,7 +27,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
   };
 
   TOFUENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TOFUENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
+  [ -n "${TOFUENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
 else
   TOFUENV_ROOT="${TOFUENV_ROOT%/}";
 fi;

--- a/test/test_use_latestallowed.sh
+++ b/test/test_use_latestallowed.sh
@@ -18,7 +18,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;
@@ -27,7 +27,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
   };
 
   TOFUENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TOFUENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
+  [ -n "${TOFUENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
 else
   TOFUENV_ROOT="${TOFUENV_ROOT%/}";
 fi;

--- a/test/test_use_minrequired.sh
+++ b/test/test_use_minrequired.sh
@@ -18,7 +18,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TOFUENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TOFUENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;
@@ -27,7 +27,7 @@ if [ -z "${TOFUENV_ROOT:-""}" ]; then
   };
 
   TOFUENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TOFUENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
+  [ -n "${TOFUENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TOFUENV_ROOT";
 else
   TOFUENV_ROOT="${TOFUENV_ROOT%/}";
 fi;


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

In the spirit of https://github.com/tfutils/tfenv/pull/426 and https://github.com/tfutils/tfenv/pull/424, this fixes various ShellCheck violations. They include:

- Prefer `&&` [instead of `-a`](https://www.shellcheck.net/wiki/SC2166)
- `[ -n` must be [used with a quoted argument](https://www.shellcheck.net/wiki/SC2070)
- Prefer `-n` [over `! -z`](https://www.shellcheck.net/wiki/SC2236)
- Avoiding [assigning an array to a string](https://www.shellcheck.net/wiki/SC2124)
- [Prefer `grep -q`](https://www.shellcheck.net/wiki/SC2143)